### PR TITLE
Fix float/integer parsing

### DIFF
--- a/Json2FSharp.Core/JsonParser.fs
+++ b/Json2FSharp.Core/JsonParser.fs
@@ -37,7 +37,10 @@ let stringOrDateTime (str: string) =
 let jstringOrDateOrGuid = stringLiteral |>> stringOrDateTime
 
 let jnumber =
-    let options = NumberLiteralOptions.AllowFraction ||| NumberLiteralOptions.AllowExponent
+    let options =
+        NumberLiteralOptions.AllowExponent |||
+        NumberLiteralOptions.AllowFraction |||
+        NumberLiteralOptions.AllowMinusSign
     numberLiteral options "number" |>> (fun x -> if x.HasFraction then JFloat else JInt)
 
 let jtrue  = stringReturn "true"  JBool

--- a/Json2FSharp.Core/JsonParser.fs
+++ b/Json2FSharp.Core/JsonParser.fs
@@ -2,7 +2,6 @@
 
 open System
 open FParsec
-open Microsoft.FSharp
 open Types
 open System.Text.RegularExpressions
 
@@ -37,7 +36,9 @@ let stringOrDateTime (str: string) =
 
 let jstringOrDateOrGuid = stringLiteral |>> stringOrDateTime
 
-let jnumber = pfloat |>> (fun x -> if x = Math.Floor(x) then JInt else JFloat)
+let jnumber =
+    let options = NumberLiteralOptions.AllowFraction ||| NumberLiteralOptions.AllowExponent
+    numberLiteral options "number" |>> (fun x -> if x.HasFraction then JFloat else JInt)
 
 let jtrue  = stringReturn "true"  JBool
 let jfalse = stringReturn "false" JBool

--- a/Json2FSharp.Tests/Tests.fs
+++ b/Json2FSharp.Tests/Tests.fs
@@ -184,10 +184,13 @@ let ``Should parse int64`` () =
         pass ()
     | _ -> fail ()
 
-[<Fact>]
-let ``Should parse float`` () =
+[<Theory()>]
+[<InlineData("3.")>]
+[<InlineData("3.4")>]
+[<InlineData("3.0")>]
+let ``Should parse float`` (value: string) =
     let root = "Root"
-    let input = @"{ ""age"": 4.2 }"
+    let input = sprintf @"{ ""age"": %s }" value
 
     let result = generateRecords FsharpCommon.fixName root FsharpCommon.listGenerator input
 

--- a/Json2FSharp.Tests/Tests.fs
+++ b/Json2FSharp.Tests/Tests.fs
@@ -172,10 +172,16 @@ let ``Should parse string`` () =
         pass ()
     | _ -> fail ()
 
-[<Fact>]
-let ``Should parse int64`` () =
+[<Theory()>]
+[<InlineData("4")>]
+[<InlineData("-4")>]
+[<InlineData("4e2")>]
+[<InlineData("-4e2")>]
+[<InlineData("4E-2")>]
+[<InlineData("4e+2")>]
+let ``Should parse int64`` (value: string) =
     let root = "Root"
-    let input = @"{ ""age"": 4 }"
+    let input = sprintf @"{ ""age"": %s }" value
 
     let result = generateRecords FsharpCommon.fixName root FsharpCommon.listGenerator input
 
@@ -184,10 +190,26 @@ let ``Should parse int64`` () =
         pass ()
     | _ -> fail ()
 
+[<Fact>]
+let ``Should fail on plus sign in numbers per specification`` () =
+    let root = "Root"
+    let input = @"{ ""age"": +4 }"
+
+    let result = generateRecords FsharpCommon.fixName root FsharpCommon.listGenerator input
+
+    match result with
+    | Ok _ ->    fail ()
+    | Error _ -> pass ()
+
 [<Theory()>]
 [<InlineData("3.")>]
 [<InlineData("3.4")>]
 [<InlineData("3.0")>]
+[<InlineData("-3.0")>]
+[<InlineData("3.e3")>]
+[<InlineData("3.02e+3")>]
+[<InlineData("3.02E-3")>]
+[<InlineData("3.02e3")>]
 let ``Should parse float`` (value: string) =
     let root = "Root"
     let input = sprintf @"{ ""age"": %s }" value


### PR DESCRIPTION
Parser now treats numbers like `3.`, `3.0` as floats